### PR TITLE
Format metadata object correctly & don't print `^$` :ghost: 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,13 +17,13 @@ export default class MetadataController {
     this.schema = {
       id: verifiedID,
       template: {
-        before: '^<!-- ',
-        after: ' -->$',
+        before: '<!-- ',
+        after: ' -->',
       },
     };
 
     this.regexp = new RegExp(
-      `${this.schema.template.before}${verifiedID} = (.*)${this.schema.template.after}`,
+      `^${this.schema.template.before}${verifiedID} = (.*)${this.schema.template.after}$`,
       'm'
     );
   }
@@ -122,7 +122,7 @@ export default class MetadataController {
     await request('PATCH /repos/{owner}/{repo}/issues/{issue_number}', {
       ...this.requestDefaults,
       issue_number: issue,
-      body: `${body}${this.schema.template.before}${
+      body: `${body}\n\n${this.schema.template.before}${
         this.schema.id
       } = ${JSON.stringify(data)}${this.schema.template.after}`,
       ...requestMock.patch,


### PR DESCRIPTION
Follow-up to https://github.com/redhat-plumbers-in-action/issue-metadata/commit/e8b95dea4a23f95e26ae6364538f4753fca6120b

Fixes issue encountered id:
- https://github.com/redhat-plumbers/systemd-rhel8/pull/385